### PR TITLE
Build without installing the apache-bin dependency

### DIFF
--- a/httpd-openidc/Dockerfile
+++ b/httpd-openidc/Dockerfile
@@ -16,7 +16,6 @@ RUN depsRuntime=" \
     libpcre3 \
     libjansson4 \
     libhiredis0.14 \
-    apache2-api-20120211 \
   " \
   && depsBuild=" \
     curl \
@@ -31,7 +30,8 @@ RUN depsRuntime=" \
   && rm libcjose.deb \
   && curl -sLSf "$OPENIDC_VERSION_DEB_URL" -o mod_auth_openidc-$OPENIDC_VERSION.deb \
   && echo "$OPENIDC_VERSION_DEB_SHA1 mod_auth_openidc-$OPENIDC_VERSION.deb" | sha1sum -c - \
-  && dpkg -i mod_auth_openidc-$OPENIDC_VERSION.deb \
+  && (dpkg -i mod_auth_openidc-$OPENIDC_VERSION.deb || echo "Accepting missing dependency") \
+  && dpkg --force-all -i mod_auth_openidc-$OPENIDC_VERSION.deb \
   && rm mod_auth_openidc-$OPENIDC_VERSION.deb \
   && ln -s /usr/lib/apache2/modules/mod_auth_openidc.so /usr/local/apache2/modules/mod_auth_openidc.so \
   && apt-get purge -y --auto-remove $depsBuild \

--- a/httpd-openidc/Dockerfile
+++ b/httpd-openidc/Dockerfile
@@ -12,17 +12,14 @@ ENV CJOSE_DEB_SHA1 d6ca5569bed04a1450e054b3280702f1edfe2ae7
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN depsRuntime=" \
-    libcurl4 ca-certificates \
+    libcurl4 ca-certificates curl \
     libpcre3 \
     libjansson4 \
     libhiredis0.14 \
   " \
-  && depsBuild=" \
-    curl \
-  " \
   set -x \
   && apt-get update \
-  && apt-get install -y --no-install-recommends $depsRuntime $depsBuild \
+  && apt-get install -y --no-install-recommends $depsRuntime \
   && rm -r /var/lib/apt/lists/* \
   && curl -sLSf "$CJOSE_DEB_URL" -o libcjose.deb \
   && echo "$CJOSE_DEB_SHA1 libcjose.deb" | sha1sum -c - \
@@ -34,7 +31,6 @@ RUN depsRuntime=" \
   && dpkg --force-all -i mod_auth_openidc-$OPENIDC_VERSION.deb \
   && rm mod_auth_openidc-$OPENIDC_VERSION.deb \
   && ln -s /usr/lib/apache2/modules/mod_auth_openidc.so /usr/local/apache2/modules/mod_auth_openidc.so \
-  && apt-get purge -y --auto-remove $depsBuild \
   && rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt
 
 RUN sed -i 's|LoadModule rewrite_module modules/mod_rewrite.so|LoadModule rewrite_module modules/mod_rewrite.so\nLoadModule auth_openidc_module modules/mod_auth_openidc.so|' conf/httpd.conf


### PR DESCRIPTION
Based on the idea from https://github.com/zmartzone/mod_auth_openidc/issues/131#issuecomment-524601194. Build output now contains the following but proceeds:

```
Preparing to unpack mod_auth_openidc-2.4.0.deb ...
Unpacking libapache2-mod-auth-openidc (2.4.0-1~buster+1) ...
dpkg: dependency problems prevent configuration of libapache2-mod-auth-openidc:
 libapache2-mod-auth-openidc depends on apache2-api-20120211; however:
  Package apache2-api-20120211 is not installed.
 libapache2-mod-auth-openidc depends on apache2-bin (>= 2.4.16); however:
  Package apache2-bin is not installed.
```
